### PR TITLE
Enforce JDK version <= 1.7 during build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -213,6 +213,27 @@
                     <parallel>none</parallel>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <message>Use Java 7 or earlier to build this project</message>
+                                    <version>(,1.8)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
Fixes #27

A NoClassDefFoundError was reported, it was due to one of the plugins we use in our build not working with JDK 1.8.

I made build fail with a meaningful message: "Use Java 7 or earlier to build this project".