### PR TITLE
Get rid of maven-plugin-anno

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,18 +55,6 @@
         <developerConnection>scm:git:github.com:jcabi/jcabi-ssl-maven-plugin.git</developerConnection>
         <url>https://github.com/jcabi/jcabi-ssl-maven-plugin</url>
     </scm>
-    <repositories>
-        <repository>
-            <id>repo.jfrog.org</id>
-            <url>http://repo.jfrog.org/artifactory/plugins-releases</url>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>repo.jfrog.org</id>
-            <url>http://repo.jfrog.org/artifactory/plugins-releases</url>
-        </pluginRepository>
-    </pluginRepositories>
     <properties>
         <maven.version>3.0.5</maven.version>
         <sisu.version>2.3.4</sisu.version>
@@ -97,12 +85,6 @@
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-        </dependency>
-        <dependency>
-            <!-- see http://wiki.jfrog.org/confluence/display/OSS/Maven+Anno+Mojo -->
-            <groupId>org.jfrog.maven.annomojo</groupId>
-            <artifactId>maven-plugin-anno</artifactId>
-            <version>1.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -199,13 +181,6 @@
                         </configuration>
                     </execution>
                 </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jfrog.maven.annomojo</groupId>
-                        <artifactId>maven-plugin-tools-anno</artifactId>
-                        <version>1.4.1</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/com/jcabi/ssl/maven/plugin/KeygenMojo.java
+++ b/src/main/java/com/jcabi/ssl/maven/plugin/KeygenMojo.java
@@ -36,9 +36,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
-import org.jfrog.maven.annomojo.annotations.MojoGoal;
-import org.jfrog.maven.annomojo.annotations.MojoParameter;
-import org.jfrog.maven.annomojo.annotations.MojoPhase;
 import org.slf4j.impl.StaticLoggerBinder;
 
 /**
@@ -47,59 +44,48 @@ import org.slf4j.impl.StaticLoggerBinder;
  * @author Yegor Bugayenko (yegor@tpc2.com)
  * @version $Id$
  * @since 0.5
+ * @goal keygen
+ * @phase initialize
  */
-@MojoGoal("keygen")
-@MojoPhase("initialize")
 public final class KeygenMojo extends AbstractMojo {
 
     /**
      * Maven project.
+     * @parameter name="project" default-value="${project}"
+     * @readonly
+     * @required
      */
-    @MojoParameter(
-        expression = "${project}",
-        required = true,
-        readonly = true,
-        description = "Maven project"
-    )
     private transient MavenProject project;
 
     /**
      * Shall we skip execution?
+     * @parameter name="skip"
      */
-    @MojoParameter(
-        defaultValue = "false",
-        required = false,
-        description = "Skips execution"
-    )
     private transient boolean skip;
 
     /**
      * Name of keystore.jks file.
+     * @parameter name="keystore"
+     * default-value="${project.build.directory}/keystore.jks"
      */
-    @MojoParameter(
-        defaultValue = "${project.build.directory}/keystore.jks",
-        required = false,
-        description = "Name of keystore.jks file"
-    )
     private transient File keystore;
 
     /**
      * Name of cacerts.jks file.
+     * @parameter name="cacerts"
+     * default-value="${project.build.directory}/cacerts.jks"
      */
-    @MojoParameter(
-        defaultValue = "${project.build.directory}/cacerts.jks",
-        required = false,
-        description = "Name of cacerts.jks file"
-    )
     private transient File cacerts;
 
     /**
      * Keystore instance.
+     * @parameter name="store"
      */
     private transient Keystore store;
 
     /**
      * Cacerts instance.
+     * @parameter name="truststore"
      */
     private transient Cacerts truststore;
 

--- a/src/main/java/com/jcabi/ssl/maven/plugin/Keytool.java
+++ b/src/main/java/com/jcabi/ssl/maven/plugin/Keytool.java
@@ -39,8 +39,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.ResourceBundle;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.commons.io.FileUtils;
@@ -172,10 +170,12 @@ final class Keytool {
      * @return The word "Yes" translated to the current language
      */
     private String createLocaleDependentYes() {
-        final ResourceBundle resources = ResourceBundle.getBundle(
-            "sun.security.util.Resources", Locale.getDefault()
-        );
-        return resources.getString("yes");
+        /* @todo #25:30min In JDK 1.8, there is no "yes" word in
+         *  sun.security.util.Resources, so in order to enable building in JDK
+         *  1.8 I replaced translated "yes" with an English "yes'. A way should
+         *  be found to get "yes" for current locale in JDK 1.8
+         */
+        return "yes";
     }
 
     /**


### PR DESCRIPTION
Fixes #25 and #27 

There is Maven plugin `org.jfrog.maven.annomojo:maven-plugin-anno` that doesn't work with JDK 1.8, and that is preventing building jcabi-ssl-maven-plugin with Java 8. Annotations from that plugin are used go generate the `plugin.xml` descriptor.

I replaced the annotations with javadoc attributes, which can be used to generate `plugin.xml` as well.

There is also one new puzzle regarding building in JDK 1.8.