### PR TITLE
Change test condition

### DIFF
--- a/src/test/java/com/jcabi/ssl/maven/plugin/KeytoolTest.java
+++ b/src/test/java/com/jcabi/ssl/maven/plugin/KeytoolTest.java
@@ -62,7 +62,7 @@ public final class KeytoolTest {
         keytool.genkey();
         MatcherAssert.assertThat(
             keytool.list(),
-            Matchers.containsString("localhost")
+            Matchers.containsString("Alias name:")
         );
     }
 


### PR DESCRIPTION
Fixes #10

@wentwog demonstrated that the string being checked does not necessarily contain a substring "localhost". I replaced that with some obligatory text that shows up as well on a successful keytool.list() invocation.