### PR TITLE
Remove extra parameters in Mojo

### DIFF
--- a/src/main/java/com/jcabi/ssl/maven/plugin/KeygenMojo.java
+++ b/src/main/java/com/jcabi/ssl/maven/plugin/KeygenMojo.java
@@ -79,13 +79,11 @@ public final class KeygenMojo extends AbstractMojo {
 
     /**
      * Keystore instance.
-     * @parameter name="store"
      */
     private transient Keystore store;
 
     /**
      * Cacerts instance.
-     * @parameter name="truststore"
      */
     private transient Cacerts truststore;
 


### PR DESCRIPTION
Fixes #25

#34 was supposed to fix #25. #34 was merged, and then @wentwog showed there are errors in the code.


In #34 I mistakingly marked two extra fields as parameters. This PR removes that extra piece of javadoc.