### PR TITLE
Update URL for Javadoc badge's image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PDD status](http://www.0pdd.com/svg?name=jcabi/jcabi-ssl-maven-plugin)](http://www.0pdd.com/p?name=jcabi/jcabi-ssl-maven-plugin)
 [![Build status](https://ci.appveyor.com/api/projects/status/n4a958g4tt5009hk/branch/master?svg=true)](https://ci.appveyor.com/project/yegor256/jcabi-ssl-maven-plugin/branch/master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-ssl-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.jcabi/jcabi-ssl-maven-plugin)
-[![Javadoc](https://javadoc-emblem.rhcloud.com/doc/com.jcabi/jcabi-ssl-maven-plugin/badge.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-ssl-maven-plugin)
+[![Javadoc](https://javadoc.io/badge/com.jcabi/jcabi-ssl-maven-plugin.svg)](http://www.javadoc.io/doc/com.jcabi/jcabi-ssl-maven-plugin)
 
 More details are here: [ssl.jcabi.com](http://ssl.jcabi.com/index.html)
 


### PR DESCRIPTION
OpenShit Online V2 is closed and this domain is not accessible anymore.
And javadoc.io introduce badges hosted directly on javadoc.io